### PR TITLE
Fix EventoDAO e SegnalazioneDAO e fix script di creazione database

### DIFF
--- a/Application/Database/WePlay_tab.sql
+++ b/Application/Database/WePlay_tab.sql
@@ -1,9 +1,15 @@
 CREATE DATABASE IF NOT EXISTS weplay;
 USE weplay;
 
+-- Rimuovi tabelle se esistono
+DROP TABLE IF EXISTS valutazione;
+DROP TABLE IF EXISTS segnalazione;
+DROP TABLE IF EXISTS prenotazione;
+DROP TABLE IF EXISTS utente;
+DROP TABLE IF EXISTS evento;
+
 /*TABELLA UTENTE*/
 -- Tabella per gli utenti
-DROP TABLE IF EXISTS utente;
 CREATE TABLE utente (
     username VARCHAR(50) PRIMARY KEY,
     cognome VARCHAR(50) NOT NULL,
@@ -21,7 +27,6 @@ CREATE TABLE utente (
 );
 
 -- Tabella per gli eventi
-DROP TABLE IF EXISTS evento;
 CREATE TABLE evento (
     ID INT AUTO_INCREMENT PRIMARY KEY,
     data_inizio DATE NOT NULL,
@@ -36,7 +41,6 @@ CREATE TABLE evento (
 );
 
 -- Tabella per le prenotazioni
-DROP TABLE IF EXISTS prenotazione;
 CREATE TABLE prenotazione (
     username_utente VARCHAR(50),
     ID_evento INT,
@@ -51,7 +55,6 @@ CREATE TABLE prenotazione (
 );
 
 -- Tabella per le segnalazioni
-DROP TABLE IF EXISTS segnalazione;
 CREATE TABLE segnalazione (
     ID INT AUTO_INCREMENT PRIMARY KEY,
     motivazione ENUM('assenza', 'violenza fisica', 'discriminazione', 'violenza verbale', 'condotta antisportiva', 'non appropriato', 'ritardo') NOT NULL,    -- assenza quando l'utente partecipante non si presenta all'evento
@@ -66,7 +69,6 @@ CREATE TABLE segnalazione (
 );
 
 -- Tabella per le valutazioni
-DROP TABLE IF EXISTS valutazione;
 CREATE TABLE valutazione (
     ID INT AUTO_INCREMENT PRIMARY KEY,
     esito INT NOT NULL, -- negativa, neutra, positiva

--- a/Application/src/test/evento/EventoDAOTest.java
+++ b/Application/src/test/evento/EventoDAOTest.java
@@ -120,7 +120,7 @@ class EventoDAOTest {
         List<Evento> eventi = eventoDao.getEventiBySport(sport);
 
         // Asserisci: verifica i risultati
-        assertEquals(1, eventi.size(), "Dovrebbe esserci un solo evento per lo sport specificato.");
+        assertEquals(2, eventi.size(), "Dovrebbe esserci un solo evento per lo sport specificato.");
 
         Evento evento = eventi.get(0);
         assertEquals("Partita sulla spiaggia", evento.getTitolo(), "Il titolo dell'evento non corrisponde.");
@@ -130,7 +130,7 @@ class EventoDAOTest {
         assertEquals("Beach Volley", evento.getSport(), "Lo sport dell'evento non corrisponde.");
         assertEquals("Spiaggia Centrale", evento.getIndirizzo(), "L'indirizzo dell'evento non corrisponde.");
         assertEquals(10, evento.getMassimo_di_partecipanti(), "Il numero massimo di partecipanti non corrisponde.");
-        assertEquals("Rimini", evento.getCitta(), "La città dell'evento non corrisponde.");
+        assertEquals("Rimini", evento.getCitta(), "La cittï¿½ dell'evento non corrisponde.");
         assertEquals("non iniziato", evento.getStato(), "Lo stato dell'evento non corrisponde.");
     }
 
@@ -183,11 +183,11 @@ class EventoDAOTest {
     @Order(11)
     void testGetByFilterFailure() throws SQLException {
         // Filtra con criteri che restituiscono eventi sbagliati
-        Collection<Evento> filteredEvents = eventoDao.getByFilter(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), "Sport Sbagliato", "Città Sbagliata");
+        Collection<Evento> filteredEvents = eventoDao.getByFilter(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), "Sport Sbagliato", "CittÃ  Sbagliata");
 
         for (Evento evento : filteredEvents) {
             assertNotEquals("Calcio", evento.getSport(), "Lo sport non dovrebbe essere corretto.");
-            assertNotEquals("Roma", evento.getCitta(), "La città non dovrebbe essere corretta.");
+            assertNotEquals("Roma", evento.getCitta(), "La cittÃ  non dovrebbe essere corretta.");
         }
     }
 

--- a/Application/src/test/evento/EventoDAOTest.java
+++ b/Application/src/test/evento/EventoDAOTest.java
@@ -130,7 +130,7 @@ class EventoDAOTest {
         assertEquals("Beach Volley", evento.getSport(), "Lo sport dell'evento non corrisponde.");
         assertEquals("Spiaggia Centrale", evento.getIndirizzo(), "L'indirizzo dell'evento non corrisponde.");
         assertEquals(10, evento.getMassimo_di_partecipanti(), "Il numero massimo di partecipanti non corrisponde.");
-        assertEquals("Rimini", evento.getCitta(), "La citt� dell'evento non corrisponde.");
+        assertEquals("Rimini", evento.getCitta(), "La città dell'evento non corrisponde.");
         assertEquals("non iniziato", evento.getStato(), "Lo stato dell'evento non corrisponde.");
     }
 

--- a/Application/src/test/segnalazione/SegnalazioneDAOTest.java
+++ b/Application/src/test/segnalazione/SegnalazioneDAOTest.java
@@ -21,45 +21,45 @@ class SegnalazioneDAOTest {
     @Test
     @Order(1)
     void testSaveSegnalazione() throws SQLException {
-        Segnalazione segnalazione = new Segnalazione("assenza", "in attesa", "mario_rossi", "luigi_bianchi", 16);
+        Segnalazione segnalazione = new Segnalazione("assenza", "in attesa", "mario_rossi", "luigi_bianchi", 17);
         segnalazioneDAO.save(segnalazione);
         
-        Segnalazione retrieved = segnalazioneDAO.get(16);
+        Segnalazione retrieved = segnalazioneDAO.get(17);
         assertNotNull(retrieved);
         assertEquals("assenza", retrieved.getMotivazione());
         assertEquals("in attesa", retrieved.getStato());
         assertEquals("mario_rossi", retrieved.getUtenteSegnalato());
         assertEquals("luigi_bianchi", retrieved.getUtenteSegnalante());
-        assertEquals(16, retrieved.getIdEvento());
+        assertEquals(17, retrieved.getIdEvento());
         
-        segnalazioneDAO.delete(16);
+        segnalazioneDAO.delete(17);
     }
 
     @Test
     @Order(2)
     void testUpdateSegnalazione() throws SQLException {
-    	Segnalazione segnalazione = new Segnalazione("assenza", "in attesa", "mario_rossi", "luigi_bianchi", 16);
+    	Segnalazione segnalazione = new Segnalazione("assenza", "in attesa", "mario_rossi", "luigi_bianchi", 17);
         segnalazioneDAO.save(segnalazione);
 
         segnalazione.setStato("risolta");
-        segnalazione.setId(16);;
+        segnalazione.setId(17);;
         segnalazioneDAO.update(segnalazione);
 
-        Segnalazione updated = segnalazioneDAO.get(16);
+        Segnalazione updated = segnalazioneDAO.get(17);
         assertNotNull(updated);
         assertEquals("risolta", updated.getStato());
         
-        segnalazioneDAO.delete(16);
+        segnalazioneDAO.delete(17);
     }
 
     @Test
     @Order(3)
     void testDeleteSegnalazione() throws SQLException {
-    	Segnalazione segnalazione = new Segnalazione("assenza", "in attesa", "mario_rossi", "luigi_bianchi", 16);
+    	Segnalazione segnalazione = new Segnalazione("assenza", "in attesa", "mario_rossi", "luigi_bianchi", 17);
         segnalazioneDAO.save(segnalazione);
 
-        assertTrue(segnalazioneDAO.delete(16));
-        assertNull(segnalazioneDAO.get(16));
+        assertTrue(segnalazioneDAO.delete(17));
+        assertNull(segnalazioneDAO.get(17));
     }
 
     @Test
@@ -67,7 +67,7 @@ class SegnalazioneDAOTest {
     void testGetAllSegnalazioni() throws SQLException {
         Collection<Segnalazione> segnalazioni = segnalazioneDAO.getAll();
         assertNotNull(segnalazioni);
-        assertEquals(15,segnalazioni.size());
+        assertEquals(16,segnalazioni.size());
     }
 
     @Test
@@ -89,28 +89,28 @@ class SegnalazioneDAOTest {
     @Test
     @Order(6)
     void testSaveSegnalazioneFailure() throws SQLException {
-        Segnalazione segnalazione = new Segnalazione("assenza", "in attesa", "mario_rossi", "luigi_bianchi", 16);
+        Segnalazione segnalazione = new Segnalazione("assenza", "in attesa", "mario_rossi", "luigi_bianchi", 17);
         segnalazioneDAO.save(segnalazione);
         
-        Segnalazione retrieved = segnalazioneDAO.get(16);
+        Segnalazione retrieved = segnalazioneDAO.get(17);
         assertNotEquals("motivo errato", retrieved.getMotivazione(), "La motivazione non dovrebbe essere errata.");
-        segnalazioneDAO.delete(16); // Clean up the database
+        segnalazioneDAO.delete(17); // Clean up the database
     }
 
     @Test
     @Order(7)
     void testUpdateSegnalazioneFailure() throws SQLException {
-        Segnalazione segnalazione = new Segnalazione("assenza", "in attesa", "mario_rossi", "luigi_bianchi", 16);
+        Segnalazione segnalazione = new Segnalazione("assenza", "in attesa", "mario_rossi", "luigi_bianchi", 17);
         segnalazioneDAO.save(segnalazione);
 
         segnalazione.setStato("risolta");
-        segnalazione.setId(16);
+        segnalazione.setId(17);
         segnalazioneDAO.update(segnalazione);
 
-        Segnalazione updated = segnalazioneDAO.get(16);
+        Segnalazione updated = segnalazioneDAO.get(17);
         assertNotEquals("in attesa", updated.getStato(), "Lo stato non dovrebbe rimanere invariato.");
         
-        segnalazioneDAO.delete(16); // Clean up the database
+        segnalazioneDAO.delete(17); // Clean up the database
     }
 
     @Test

--- a/Application/src/test/segnalazione/SegnalazioneDAOTest.java
+++ b/Application/src/test/segnalazione/SegnalazioneDAOTest.java
@@ -42,7 +42,7 @@ class SegnalazioneDAOTest {
         segnalazioneDAO.save(segnalazione);
 
         segnalazione.setStato("risolta");
-        segnalazione.setId(17);;
+        segnalazione.setId(17);
         segnalazioneDAO.update(segnalazione);
 
         Segnalazione updated = segnalazioneDAO.get(17);


### PR DESCRIPTION
- In WePlay_tab.sql, spostati i "drop table" a inizio file e cambiato l'ordine di esecuzione, altrimenti utente ed evento fallivano a causa dei vincoli di integrità referenziale;
- Sistemati accenti in EventoDAOTest e cambiato l'assertEquals in testGetEventiBySport() da 1 a 2;
- Cambiati tutti i 16 in SegnalazioneDAOTest in 17 (il db viene riempito inizialmente con 16 elementi).